### PR TITLE
comparing evaluation not strings

### DIFF
--- a/src/JuliaTutor.jl
+++ b/src/JuliaTutor.jl
@@ -17,19 +17,27 @@ module JuliaTutor
         exit_attempt(userinput) && exit()
     end
 
-    function evaluate(ui, ans)::Tuple{ Bool, Bool }
+    function evaluate(ui, var, ans)::Tuple{ Bool, Bool }
         #try to run the users code
-        syntax_error,incorrect_answer = false, false;
+        syntax_error, incorrect_answer = false, false;
+        ui_ex = Meta.parse(ui)
         try
-            eval(ui)
+            eval(ui_ex)
         catch
             syntax_error = true;
         end
-        incorrect_answer = !(ui == ans)
+        # check whether the variable is defined
+        try
+            eval(var)
+        catch
+            incorrect_answer = true;
+        end
+        # if defined check whether it is set to the correct answer
+        !incorrect_answer && (incorrect_answer = !(eval(var) == ans))
         return (syntax_error, incorrect_answer)
     end
 
-    function request_read_evaluate(request, answer)
+    function request_read_evaluate(request, var, answer)
         print( Crayon( foreground = :red, bold = true ),
                  "> ")
         println( Crayon( foreground = :white, bold = true ),
@@ -40,7 +48,7 @@ module JuliaTutor
             print( Crayon( foreground = :green ), "> ")
             userinput = readline()
             exit_attempt(userinput) && exit()
-            (syntax_error, incorrect_answer) = evaluate(userinput, answer)
+            (syntax_error, incorrect_answer) = evaluate(userinput, var, answer)
             if syntax_error
                 println(Crayon( foreground = :white, italics = true ),
                         "Sorry it appears there is a syntax error in your code.")

--- a/src/JuliaTutor.jl
+++ b/src/JuliaTutor.jl
@@ -33,7 +33,7 @@ module JuliaTutor
             incorrect_answer = true;
         end
         # if defined check whether it is set to the correct answer
-        !incorrect_answer && (incorrect_answer = !(eval(var) == ans))
+        !incorrect_answer && (incorrect_answer = !(eval(var) === ans))
         return (syntax_error, incorrect_answer)
     end
 

--- a/src/tst.jl
+++ b/src/tst.jl
@@ -9,4 +9,5 @@ maybe some long instruction set!
 maybe someone droning on and on about julia?""" |> inform
 
 request_read_evaluate( "Define a variable `a` to be the integer 1234",
-                    "a=1234")
+                    :a, 1234)
+


### PR DESCRIPTION
Currently you compare strings such that `a = 1234` is not valid (because of the spaces). 
Some people might even write `a = 1_234`. This PR checks it a bit different.

- Parse the expression entered and evaluate it
- Check if the correct variable is defined 
- Check if the variable is set to the correct value

One needs to define the answer then in this example:

```
request_read_evaluate( "Define a variable `a` to be the integer 1234",
                    :a, 1234)
```

There are probably better ways to do this :smile: 